### PR TITLE
Corrected grammatical error

### DIFF
--- a/app/controllers/scoreboard_controller.rb
+++ b/app/controllers/scoreboard_controller.rb
@@ -16,7 +16,7 @@ class ScoreboardController < ApplicationController
     @leading_year = highest_year_score.positive? ? 
     "Lead Year#{leading_years.size > 1 ? 's' : ''}: " + 
     leading_years.map(&:year).join(", ") : 
-    "Lead Year N/A"  
+    "Lead Year: N/A"  
 
     # Calculate the leading forms
     form_scores = calculate_form_scores(year_totals)


### PR DESCRIPTION
I added a missing colon to the Lead Year text.

Previous:
![image](https://github.com/user-attachments/assets/281e676b-b398-4764-bf5b-672f4c9fb0df)

Updated:
![image](https://github.com/user-attachments/assets/5b823941-c150-48d8-a091-b26a050d9f4f)
