### PR TITLE
Update scoreboard_controller.rb

### DIFF
--- a/app/controllers/scoreboard_controller.rb
+++ b/app/controllers/scoreboard_controller.rb
@@ -16,7 +16,7 @@ class ScoreboardController < ApplicationController
     @leading_year = highest_year_score.positive? ? 
     "Lead Year#{leading_years.size > 1 ? 's' : ''}: " + 
     leading_years.map(&:year).join(", ") : 
-    "Lead Year: N/A"  
+    "Lead Year: Not Applicable"  
 
     # Calculate the leading forms
     form_scores = calculate_form_scores(year_totals)
@@ -24,7 +24,7 @@ class ScoreboardController < ApplicationController
     @leading_form = top_form_score.positive? ? 
     "Lead Form#{form_scores.select { |_form, score| score == top_form_score }.keys.size > 1 ? 's' : ''}: " + 
     form_scores.select { |_form, score| score == top_form_score }.keys.join(", ") : 
-    "Lead Form: N/A"
+    "Lead Form: Not Applicable"
   
   end
 


### PR DESCRIPTION
Accessibility in communication is crucial for ensuring that information is easily understood by a diverse audience. While abbreviations like "N/A" are widely used, replacing them with "Not Applicable" improves accessibility, clarity, and inclusivity across various contexts. Below are the reasons why "Not Applicable" is a better alternative.

#### 1. **Clarity and Comprehension**

"Not Applicable" is explicit and does not require interpretation. Abbreviations like "N/A" can be unclear to certain users, such as:

- **Non-native speakers**: Abbreviations may not be intuitive for individuals who are less familiar with English.
- **Low-literacy individuals**: Full phrases are easier to process, eliminating the need to decipher shorthand.
- **First-time readers**: People encountering formal documents for the first time are more likely to understand full phrases than abbreviations.

By using the full phrase, communication becomes clearer and more accessible to everyone, regardless of their background or proficiency in English.

#### 2. **Eliminating Ambiguity**

Abbreviations can have multiple interpretations. For example, "N/A" might be read as "Not Available," "No Answer," or "Not Applicable," depending on the context. This ambiguity can lead to confusion, especially in critical fields like healthcare or legal documentation. The explicit nature of "Not Applicable" removes the risk of misinterpretation.

#### 3. **Alignment with Accessibility Standards**

Replacing "N/A" with "Not Applicable" aligns with established accessibility and inclusivity principles, such as:

- **Plain Language Standards**: Many organizations advocate for avoiding abbreviations to enhance understanding for all users.
- **Web Content Accessibility Guidelines (WCAG)**: Clear and simple language improves accessibility for individuals with cognitive or learning disabilities. Full phrases are more user-friendly than abbreviations, which can be cryptic or require explanation.

#### 4. **Better for Assistive Technologies**

In digital contexts, assistive tools like screen readers often struggle with abbreviations. For instance, "N/A" might be read as "En Slash A," which can disrupt comprehension. Conversely, "Not Applicable" is read as intended, providing a seamless experience for users relying on these technologies.

#### 5. **Consistency and Professionalism**

Using "Not Applicable" ensures consistency across documents and interfaces. Abbreviations can sometimes appear informal or overly technical. By standardizing the use of full phrases, organizations can maintain a professional tone while making their content universally understandable.

#### 6. **Inclusivity in Global Communication**

Abbreviations like "N/A" may not be universally recognized, especially by individuals from non-English-speaking backgrounds. "Not Applicable" transcends linguistic and cultural barriers, making it a more inclusive choice for international audiences.

#### Conclusion

Replacing "N/A" with "Not Applicable" enhances clarity, accessibility, and inclusivity. It ensures that information is easily understood by a broader audience, including non-native speakers, individuals with cognitive challenges, and users of assistive technologies. By adopting "Not Applicable" as the standard, communication becomes more effective and universally accessible.